### PR TITLE
Prices can be returned as null.

### DIFF
--- a/Tankerkoenig.Net/Data/DetailedStation.cs
+++ b/Tankerkoenig.Net/Data/DetailedStation.cs
@@ -19,9 +19,9 @@ public record DetailedStation(
    [property: JsonPropertyName("overrides")] IReadOnlyList<object> Overrides,
    [property: JsonPropertyName("wholeDay")] bool WholeDay,
    [property: JsonPropertyName("isOpen")] bool IsOpen,
-   [property: JsonPropertyName("e5")] double E5,
-   [property: JsonPropertyName("e10")] double E10,
-   [property: JsonPropertyName("diesel")] double Diesel,
+   [property: JsonPropertyName("e5")] double? E5,
+   [property: JsonPropertyName("e10")] double? E10,
+   [property: JsonPropertyName("diesel")] double? Diesel,
    [property: JsonPropertyName("lat")] double Lat,
    [property: JsonPropertyName("lng")] double Lng,
    [property: JsonPropertyName("state")] object? State

--- a/Tankerkoenig.Net/Data/IStation.cs
+++ b/Tankerkoenig.Net/Data/IStation.cs
@@ -2,9 +2,9 @@
 
 public interface IStation {
     string Brand { get; init; }
-    double Diesel { get; init; }
-    double E10 { get; init; }
-    double E5 { get; init; }
+    double? Diesel { get; init; }
+    double? E10 { get; init; }
+    double? E5 { get; init; }
     string HouseNumber { get; init; }
     Guid Id { get; init; }
     bool IsOpen { get; init; }

--- a/Tankerkoenig.Net/Data/Station.cs
+++ b/Tankerkoenig.Net/Data/Station.cs
@@ -16,9 +16,9 @@ public record Station(
     [property: JsonPropertyName("lat")] double Lat,
     [property: JsonPropertyName("lng")] double Lng,
     [property: JsonPropertyName("dist")] double Dist,
-    [property: JsonPropertyName("diesel")] double Diesel,
-    [property: JsonPropertyName("e5")] double E5,
-    [property: JsonPropertyName("e10")] double E10,
+    [property: JsonPropertyName("diesel")] double? Diesel,
+    [property: JsonPropertyName("e5")] double? E5,
+    [property: JsonPropertyName("e10")] double? E10,
     [property: JsonPropertyName("isOpen")] bool IsOpen,
     [property: JsonPropertyName("houseNumber")] string HouseNumber,
     [property: JsonPropertyName("postCode")] int PostCode


### PR DESCRIPTION
E.g. station with ID "005056a9-779e-1edd-b8d1-136a2daa1b69" returns diesel: null